### PR TITLE
Use `-testcontrols` mode to capture a stable image

### DIFF
--- a/vgret.doom.toml
+++ b/vgret.doom.toml
@@ -6,7 +6,7 @@
 [capture]
 	method = 'generic_screenshot'
 	# wait_ms = X # Wait X amount of milliseconds *after* process start, *before* capturing
-	flags = [] # Flags passed to the *app* e.g.: ['--run-in-background','-d ...'] etc.
+	flags = ['-testcontrols'] # Flags passed to the *app* e.g.: ['--run-in-background','-d ...'] etc.
 
 # List of apps to run and capture
 [[apps]]
@@ -14,7 +14,7 @@
     # Capture screen size is 640x480 @ 24bit color depth
 	path = 'chocolate-doom/src/doom/doomv'
     [apps.capture]
-		wait_ms = 30000 # 30 secs. The game *should* have started and reached into kiosk-mode at this point
+		wait_ms = 7000 # 7 secs. The game *should* have started and rendered a stable image at this point
 		regions = [
             { x = 450, y = 405, width = 85,  height = 44 } # Red lump to the right, next to the armour level
             { x = 0,   y = 450, width = 300, height = 30 } # Bottom left UI + shareware text


### PR DESCRIPTION

That mode bypasses the title screen animations and the demo after that. With that parameter, the rendered screen is more or less stable, except for the avatar face animation in the bottom middle. The doom guy is also in a room without enemies, so the health/ammo will also stay stable. 

I hope that running Doom for 5-10 seconds in this mode, will be enough to get a stable image (except for the player face area).